### PR TITLE
Improve 2D sweep generation workflow and demo safeguards

### DIFF
--- a/VASP GUI
+++ b/VASP GUI
@@ -2417,10 +2417,18 @@ class VaspGUI(tk.Tk):
         self.title(f"{APP_NAME}")
         self.geometry("1200x800")
         if HAS_TTKBOOTSTRAP and tb is not None:
+            style = None
             try:
-                tb.Style("cosmo")
+                style = tb.Style()
             except Exception:
-                pass
+                style = None
+            if style is not None:
+                for theme in ("cosmo", "flatly", "darkly", "minty"):
+                    try:
+                        style.theme_use(theme)
+                        break
+                    except Exception:
+                        continue
 
         self.project_dir = Path.cwd()
         self.proc = None  # subprocess.Popen or None
@@ -3156,6 +3164,11 @@ class VaspGUI(tk.Tk):
         top = tk.Toplevel(self)
         top.title(title)
         top.geometry("720x380")
+        try:
+            top.update_idletasks()
+            top.wm_minsize(640, 320)
+        except Exception:
+            pass
         lb = tk.Listbox(top, selectmode=tk.SINGLE)
         for it in items:
             lb.insert(tk.END, it)
@@ -3427,7 +3440,8 @@ class VaspGUI(tk.Tk):
         ttk.Separator(left, orient=tk.HORIZONTAL).pack(fill=tk.X, pady=6)
 
         # 基本几何参数
-        self.tw_vacuum = tk.DoubleVar(value=20.0)     # 目标真空 (Å)
+        self.tw_vacuum = tk.DoubleVar(value=20.0)     # 真空厚度 (Å)
+        self.tw_interlayer = tk.DoubleVar(value=3.35)  # 层间距 (Å)
         self.tw_allow_strain = tk.DoubleVar(value=0.8)  # 允许等效小应变（%）
         self.tw_gamma_atom_threshold = tk.IntVar(value=500)  # 超大超胞→Gamma-only
         self.tw_enable_twist = tk.BooleanVar(value=True)
@@ -3435,8 +3449,12 @@ class VaspGUI(tk.Tk):
 
         self._add_section_heading(left, "基本几何参数", help_vacuum, title="真空与容许应变")
         row = ttk.Frame(left); row.pack(fill=tk.X, pady=2)
-        ttk.Label(row, text="真空(Å):").pack(side=tk.LEFT); ttk.Entry(row, textvariable=self.tw_vacuum, width=7).pack(side=tk.LEFT, padx=4)
-        ttk.Label(row, text="容许应变(%)").pack(side=tk.LEFT, padx=(8,0)); ttk.Entry(row, textvariable=self.tw_allow_strain, width=7).pack(side=tk.LEFT, padx=4)
+        ttk.Label(row, text="真空(Å):").pack(side=tk.LEFT)
+        ttk.Entry(row, textvariable=self.tw_vacuum, width=7).pack(side=tk.LEFT, padx=4)
+        ttk.Label(row, text="层间距(Å)").pack(side=tk.LEFT, padx=(8, 0))
+        ttk.Entry(row, textvariable=self.tw_interlayer, width=7).pack(side=tk.LEFT, padx=4)
+        ttk.Label(row, text="容许应变(%)").pack(side=tk.LEFT, padx=(8,0))
+        ttk.Entry(row, textvariable=self.tw_allow_strain, width=7).pack(side=tk.LEFT, padx=4)
 
         dim_frame = ttk.LabelFrame(left, text="扫描维度")
         dim_frame.pack(fill=tk.X, pady=4)
@@ -3489,7 +3507,7 @@ class VaspGUI(tk.Tk):
         ttk.Button(btns, text="批量遍历并生成", command=lambda: self._tw_generate(single=False)).pack(side=tk.LEFT)
 
         ttk.Separator(left, orient=tk.HORIZONTAL).pack(fill=tk.X, pady=6)
-        ttk.Button(left, text="解析 sweep 结果 → CSV", command=self._tw_collect_results).pack(anchor=tk.W)
+        ttk.Button(left, text="解析 sweep 结果 → CSV", command=self._tw_collect_results_btn).pack(anchor=tk.W)
         ttk.Button(left, text="绘制 gap 热图（用当前 θ）", command=self._tw_plot_gap_heatmap_btn).pack(anchor=tk.W, pady=(4, 0))
         ttk.Button(left, text="绘制 gap–θ 曲线（min/mean/max）", command=self._tw_plot_gap_vs_theta_btn).pack(anchor=tk.W, pady=(4, 8))
 
@@ -3530,6 +3548,53 @@ class VaspGUI(tk.Tk):
                 self.tw_log.configure(state=tk.DISABLED)
             except Exception:
                 pass
+
+    def _set_busy(self, busy: bool, message: str | None = None) -> None:
+        """轻量设置 Busy 光标，并可选记录日志。"""
+        try:
+            self.configure(cursor="watch" if busy else "")
+        except Exception:
+            pass
+        if message:
+            self._tw_append_log(message)
+        try:
+            self.update_idletasks()
+        except Exception:
+            pass
+
+    def _run_bg(self, target: Callable, *args, on_done=None, on_error=None):
+        """在后台线程执行 target，完成后在主线程回调。"""
+        import threading
+        import queue
+
+        q: "queue.Queue[tuple[str, object]]" = queue.Queue(maxsize=1)
+
+        def _worker():
+            try:
+                res = target(*args)
+                q.put(("ok", res))
+            except Exception as exc:  # noqa: BLE001
+                q.put(("err", exc))
+
+        threading.Thread(target=_worker, daemon=True).start()
+
+        def _poll():
+            try:
+                kind, payload = q.get_nowait()
+            except Exception:
+                try:
+                    self.after(120, _poll)
+                except Exception:
+                    pass
+                return
+            if kind == "ok":
+                if callable(on_done):
+                    on_done(payload)
+            else:
+                if callable(on_error):
+                    on_error(payload)
+
+        self.after(120, _poll)
     # === CODEX END: twist/shift page UI ===
 
     # === CODEX BEGIN: twist/shift geometry core ===
@@ -3544,6 +3609,7 @@ class VaspGUI(tk.Tk):
                 Path(self.tw_top_path.get()), Path(self.tw_bot_path.get()),
                 theta_deg=float(self.tw_theta_a.get()), ux=0.0, uy=0.0,
                 vacuum=float(self.tw_vacuum.get()),
+                interlayer=float(self.tw_interlayer.get()),
                 allow_strain=float(self.tw_allow_strain.get())/100.0,
                 search_limit=8
             )
@@ -3689,10 +3755,18 @@ class VaspGUI(tk.Tk):
     def _estimate_atoms(self, st_top, st_bot, best):
         return len(st_top) * (best["n1"] * best["m1"]) + len(st_bot) * (best["n2"] * best["m2"])
 
-    def _tw_build_structure(self, top_path: Path, bot_path: Path,
-                            theta_deg: float, ux: float, uy: float,
-                            vacuum: float, allow_strain: float,
-                            search_limit: int = 8):
+    def _tw_build_structure(
+        self,
+        top_path: Path,
+        bot_path: Path,
+        theta_deg: float,
+        ux: float,
+        uy: float,
+        vacuum: float,
+        interlayer: float,
+        allow_strain: float,
+        search_limit: int = 8,
+    ):
         """
         构造扭转(θ) + 滑移(u_x,u_y) 的双层结构，并尽量用对角超胞近似共格。
         返回 (Structure, meta)；如果找不到低应变解，抛出异常。
@@ -3752,8 +3826,11 @@ class VaspGUI(tk.Tk):
 
         # 最终公共 in-plane 晶格使用 B（下层超胞矩阵 B）
         B = A_bot @ np.array([[best["n2"],0],[0,best["m2"]]], dtype=int)
-        # 组 3×3 晶格矩阵：c 轴重置为目标真空
-        c_len = float(vacuum)
+        # 组 3×3 晶格矩阵：c 轴由层间距 + 真空决定
+        interlayer = float(interlayer)
+        if interlayer <= 0:
+            raise ValueError("层间距需为正数")
+        c_len = float(vacuum) + interlayer
         L_final = np.array([[B[0,0], B[0,1], 0.0],
                             [B[1,0], B[1,1], 0.0],
                             [0.0,    0.0,    c_len]], dtype=float)
@@ -3773,9 +3850,11 @@ class VaspGUI(tk.Tk):
         t_frac_final[:,0] = (t_frac_final[:,0] + ux) % 1.0
         t_frac_final[:,1] = (t_frac_final[:,1] + uy) % 1.0
 
-        # 分层放置在 z（0.4 与 0.6）
-        b_frac_final[:,2] = 0.40
-        t_frac_final[:,2] = 0.60
+        # 分层放置在 z：底层位于真空中心偏下，上层位于其上 interlayer 处
+        z_bot = 0.5 * c_len - 0.5 * interlayer
+        z_top = z_bot + interlayer
+        b_frac_final[:,2] = z_bot / c_len
+        t_frac_final[:,2] = z_top / c_len
 
         # 合并为一个 Structure
         species = []
@@ -3792,10 +3871,20 @@ class VaspGUI(tk.Tk):
 
         st_final = Structure(Lattice(L_final), species, frac, site_properties=props)
 
-        meta = dict(theta_deg=float(theta_deg), ux=float(ux), uy=float(uy),
-                    atoms=len(st_final), n1=best["n1"], m1=best["m1"],
-                    n2=best["n2"], m2=best["m2"], strain_scale=s,
-                    resid=best["resid"])
+        meta = dict(
+            theta_deg=float(theta_deg),
+            ux=float(ux),
+            uy=float(uy),
+            atoms=len(st_final),
+            n1=best["n1"],
+            m1=best["m1"],
+            n2=best["n2"],
+            m2=best["m2"],
+            strain_scale=s,
+            resid=best["resid"],
+            vacuum=float(vacuum),
+            interlayer=interlayer,
+        )
         return st_final, meta
     # === CODEX END: twist/shift geometry core ===
 
@@ -3842,13 +3931,14 @@ class VaspGUI(tk.Tk):
         return (ux_mod, uy_mod)
 
     def _tw_generate(self, single: bool):
-        """生成单例或批量遍历任务目录与 POSCAR/INCAR。"""
+        """在后台生成单例或批量遍历任务目录。"""
         try:
             theta_a = float(self.tw_theta_a.get())
             theta_b = float(self.tw_theta_b.get())
             theta_step = float(self.tw_theta_step.get())
             vacuum = float(self.tw_vacuum.get())
-            allow_strain = float(self.tw_allow_strain.get())/100.0
+            interlayer = float(self.tw_interlayer.get())
+            allow_strain = float(self.tw_allow_strain.get()) / 100.0
             kspacing = float(self.tw_kspacing.get())
             ux_steps = int(self.tw_ux_steps.get())
             uy_steps = int(self.tw_uy_steps.get())
@@ -3862,6 +3952,8 @@ class VaspGUI(tk.Tk):
         issues = []
         if vacuum <= 0:
             issues.append("真空(Å) 必须为正数。")
+        if interlayer <= 0:
+            issues.append("层间距(Å) 必须为正数。")
         if allow_strain < 0:
             issues.append("容许应变(%) 不能为负值。")
         if kspacing <= 0:
@@ -3879,16 +3971,108 @@ class VaspGUI(tk.Tk):
             self._tw_append_log("参数校验失败：" + "；".join(issues))
             return
 
-        if slide_enabled:
-            slide_enabled = slide_enabled and ux_steps > 0 and uy_steps > 0
-
-        top_p = Path(self.tw_top_path.get()); bot_p = Path(self.tw_bot_path.get())
+        top_p = Path(self.tw_top_path.get())
+        bot_p = Path(self.tw_bot_path.get())
         if not top_p.exists() or not bot_p.exists():
             messagebox.showwarning(APP_NAME, "请先选择上/下层 POSCAR")
             self._tw_append_log("未找到上/下层 POSCAR，生成流程已中止。")
             return
 
-        # 任务组合
+        project_path = self.current_project_path()
+        autorun = bool(self.tw_autorun.get()) if hasattr(self, "tw_autorun") else False
+
+        incar_src = project_path / "INCAR"
+        if incar_src.exists():
+            incar_text = read_text(incar_src)
+        else:
+            try:
+                incar_text = self.incar_text.get("1.0", tk.END)
+            except Exception:
+                incar_text = ""
+
+        params = dict(
+            single=single,
+            theta_a=theta_a,
+            theta_b=theta_b,
+            theta_step=theta_step,
+            vacuum=vacuum,
+            interlayer=interlayer,
+            allow_strain=allow_strain,
+            kspacing=kspacing,
+            ux_steps=ux_steps,
+            uy_steps=uy_steps,
+            max_tasks=max_tasks,
+            twist_enabled=twist_enabled,
+            slide_enabled=slide_enabled,
+            top_path=top_p,
+            bot_path=bot_p,
+            project_path=project_path,
+            incar_text=incar_text,
+            autorun=autorun,
+        )
+
+        busy_msg = "正在生成单例任务…" if single else "正在批量生成 twist_sweep 任务…"
+        self._set_busy(True, busy_msg)
+
+        def _on_done(result: dict):
+            self._set_busy(False)
+            if not isinstance(result, dict):
+                return
+            for msg in result.get("logs", []):
+                self._tw_append_log(msg)
+            preview = result.get("preview")
+            if preview:
+                try:
+                    st_obj, meta = preview
+                    self._tw_draw_topview(st_obj, meta)
+                except Exception as exc:  # noqa: BLE001
+                    self._tw_append_log(f"预览绘制失败：{exc}")
+            info_msg = result.get("info_msg")
+            if info_msg:
+                messagebox.showinfo(APP_NAME, info_msg)
+            warn_msg = result.get("warn_msg")
+            if warn_msg:
+                messagebox.showwarning(APP_NAME, warn_msg)
+            self.refresh_project_overview()
+
+        def _on_error(exc: Exception):
+            self._set_busy(False)
+            self._tw_append_log(f"生成失败：{exc}")
+            messagebox.showerror(APP_NAME, f"生成失败：{exc}")
+
+        self._run_bg(self._tw_generate_core, params, on_done=_on_done, on_error=_on_error)
+
+    def _tw_generate_core(self, params: dict) -> dict:
+        """后台执行的核心逻辑：返回日志与结果摘要。"""
+        logs: list[str] = []
+        single = params["single"]
+        theta_a = float(params["theta_a"])
+        theta_b = float(params["theta_b"])
+        theta_step = float(params["theta_step"])
+        vacuum = float(params["vacuum"])
+        interlayer = float(params["interlayer"])
+        allow_strain = float(params["allow_strain"])
+        kspacing = float(params["kspacing"])
+        ux_steps = int(params["ux_steps"])
+        uy_steps = int(params["uy_steps"])
+        max_tasks = int(params["max_tasks"])
+        twist_enabled = bool(params["twist_enabled"])
+        slide_enabled = bool(params["slide_enabled"])
+        top_p: Path = Path(params["top_path"])
+        bot_p: Path = Path(params["bot_path"])
+        project_path: Path = Path(params["project_path"])
+        incar_text: str = params.get("incar_text", "")
+        autorun = bool(params.get("autorun", False))
+
+        import importlib
+
+        np_mod = None
+        if HAS_NUMPY:
+            try:
+                np_mod = importlib.import_module("numpy")
+            except Exception:  # noqa: BLE001
+                np_mod = None
+
         if single or not twist_enabled:
             thetas = [theta_a]
         else:
@@ -3907,12 +4091,14 @@ class VaspGUI(tk.Tk):
                 from pymatgen.core import Structure as _Structure
 
                 st_bot_sample = _Structure.from_file(str(bot_p))
-                lattice2x2 = np.array(st_bot_sample.lattice.matrix[:2, :2])
+                if np_mod is None:
+                    raise RuntimeError("numpy 未可用")
+                lattice2x2 = np_mod.array(st_bot_sample.lattice.matrix[:2, :2])
             except Exception:
                 lattice2x2 = None
 
-        combos = []
-        seen = set()
+        combos: list[tuple[float, float, float]] = []
+        seen: set[tuple[float, float, float]] = set()
         for th in thetas:
             for ux in uxs:
                 for uy in uys:
@@ -3926,104 +4112,109 @@ class VaspGUI(tk.Tk):
                     seen.add(key)
                     combos.append((th, float(cu[0]), float(cu[1])))
 
-        self._tw_append_log(
-            f"开始生成：θ 数量={len(thetas)}, u_x 数量={len(uxs)}, u_y 数量={len(uys)}，总计 {len(combos)} 个组合")
+        logs.append(
+            f"开始生成：θ 数量={len(thetas)}, u_x 数量={len(uxs)}, u_y 数量={len(uys)}，总计 {len(combos)} 个组合"
+        )
         if len(combos) > max_tasks:
-            messagebox.showwarning(APP_NAME, f"任务数 {len(combos)} > 上限 {max_tasks}，请降低分辨率或步长")
-            self._tw_append_log(f"任务数 {len(combos)} 超出上限 {max_tasks}，未执行生成。")
-            return
+            raise RuntimeError(f"任务数 {len(combos)} > 上限 {max_tasks}，请调整步长或网格。")
 
-        proj = self.current_project_path()
-        root = proj / "twist_sweep"
+        root = project_path / "twist_sweep"
         root.mkdir(parents=True, exist_ok=True)
 
-        made = 0; skipped = 0
+        made = 0
+        skipped = 0
+        last_preview: tuple | None = None
+        warn_msg = None
+
         for th, ux, uy in combos:
-            name = f"theta_{th:+06.2f}_ux_{ux:0.3f}_uy_{uy:0.3f}".replace("+","")
-            w = root / name
-            w.mkdir(parents=True, exist_ok=True)
-            self._tw_append_log(f"构建 θ={th:.3f}°, u=({ux:.3f},{uy:.3f}) → {w.name}")
+            name = f"theta_{th:+06.2f}_ux_{ux:0.3f}_uy_{uy:0.3f}".replace("+", "")
+            workdir = root / name
+            workdir.mkdir(parents=True, exist_ok=True)
+            logs.append(f"构建 θ={th:.3f}°, u=({ux:.3f},{uy:.3f}) → {workdir.name}")
             try:
-                st, meta = self._tw_build_structure(top_p, bot_p, th, ux, uy, vacuum, allow_strain, search_limit=8)
-            except Exception as e:
-                # 写个失败标记
-                write_text(w / "FAILED.txt", f"{e}\n")
+                st, meta = self._tw_build_structure(
+                    top_p,
+                    bot_p,
+                    th,
+                    ux,
+                    uy,
+                    vacuum,
+                    interlayer,
+                    allow_strain,
+                    search_limit=8,
+                )
+            except Exception as exc:  # noqa: BLE001
+                write_text(workdir / "FAILED.txt", f"{exc}\n")
                 skipped += 1
-                self._tw_append_log(f"构建失败：θ={th:.3f}°, u=({ux:.3f},{uy:.3f})，原因：{e}")
-                continue
-            # 写 POSCAR
-            try:
-                st.to(fmt="poscar", filename=str(w / "POSCAR"))
-            except Exception as e:
-                write_text(w / "FAILED.txt", f"写 POSCAR 失败: {e}\n")
-                skipped += 1
-                self._tw_append_log(f"写入 POSCAR 失败：{e}")
+                logs.append(
+                    f"构建失败：θ={th:.3f}°, u=({ux:.3f},{uy:.3f})，原因：{exc}"
+                )
                 continue
 
-            # 准备 INCAR：从项目拷贝或用当前编辑器，补丁 2D 设置 + ISYM=0 + KSPACING
-            incar_src = proj / "INCAR"
-            if incar_src.exists():
-                incar_text = read_text(incar_src)
-            else:
-                incar_text = self.incar_text.get("1.0", tk.END)
+            try:
+                st.to(fmt="poscar", filename=str(workdir / "POSCAR"))
+            except Exception as exc:  # noqa: BLE001
+                write_text(workdir / "FAILED.txt", f"写 POSCAR 失败: {exc}\n")
+                skipped += 1
+                logs.append(f"写入 POSCAR 失败：{exc}")
+                continue
 
             patch = {
                 "ISYM": "0",
                 "KSPACING": f"{kspacing}",
                 "LWAVE": ".FALSE.",
                 "LCHARG": ".TRUE.",
+                "LDIPOL": ".TRUE.",
+                "IDIPOL": "3",
             }
-            # 2D 建议：去极化/偶极修正
-            more2d = {"LDIPOL": ".TRUE.", "IDIPOL": "3"}
-            patch.update(more2d)
-
             incar_new = self._update_incar_text(incar_text, patch)
-            write_text(w / "INCAR", incar_new)
+            write_text(workdir / "INCAR", incar_new)
 
-            # KPOINTS：建议不写（让 KSPACING 生效）。若用户执意存在 KPOINTS，可忽略或提示
-            # POTCAR：若项目下已有则复制
-            pot = proj / "POTCAR"
+            pot = project_path / "POTCAR"
             if pot.exists():
                 try:
-                    shutil.copyfile(pot, w / "POTCAR")
+                    shutil.copyfile(pot, workdir / "POTCAR")
                 except Exception:
                     pass
 
-            # 记录元数据
-            meta_path = w / "meta.json"
-            meta2 = dict(meta); meta2.update(dict(path=str(w)))
-            (w / "meta.json").write_text(json.dumps(meta2, ensure_ascii=False, indent=2), encoding="utf-8")
+            meta_path = workdir / "meta.json"
+            meta2 = dict(meta)
+            meta2.update(dict(path=str(workdir)))
+            meta_path.write_text(json.dumps(meta2, ensure_ascii=False, indent=2), encoding="utf-8")
 
             made += 1
+            last_preview = (st, meta2)
+            logs.append(f"完成：{workdir.name}，原子数 {len(st)}")
 
-            try:
-                self._tw_draw_topview(st, meta2)
-            except Exception:
-                pass
-            else:
-                self._tw_append_log(f"完成：{w.name}，原子数 {len(st)}")
-
-            # 可选：自动运行（实验性，依赖你的 run_local.sh 逻辑）
-            if self.tw_autorun.get():
-                # 简化：在该子目录下直接调用项目的 run_local.sh（需要 vasp 命令可用）
+            if autorun:
                 try:
-                    # 复制 run 脚本
-                    for script in ("run_local.sh","run_slurm.sh"):
-                        if (proj / script).exists():
-                            shutil.copyfile(proj / script, w / script)
-                            os.chmod(w / script, 0o755)
-                    # 后台起本地
-                    if (w / "run_local.sh").exists():
-                        subprocess.Popen(["bash","-lc", f"cd '{w}' && ./run_local.sh"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True)
-                        self._tw_append_log(f"已触发自动运行：{w.name}/run_local.sh")
-                except Exception as exc:
-                    self._tw_append_log(f"自动运行触发失败：{w.name}，原因：{exc}")
-                    pass
+                    for script in ("run_local.sh", "run_slurm.sh"):
+                        src = project_path / script
+                        if src.exists():
+                            shutil.copyfile(src, workdir / script)
+                            os.chmod(workdir / script, 0o755)
+                    run_script = workdir / "run_local.sh"
+                    if run_script.exists():
+                        subprocess.Popen(
+                            ["bash", "-lc", f"cd '{workdir}' && ./run_local.sh"],
+                            stdout=subprocess.DEVNULL,
+                            stderr=subprocess.DEVNULL,
+                            start_new_session=True,
+                        )
+                        logs.append(f"已触发自动运行：{workdir.name}/run_local.sh")
+                except Exception as exc:  # noqa: BLE001
+                    warn_msg = f"自动运行触发失败：{workdir.name}，原因：{exc}"
+                    logs.append(warn_msg)
 
-        messagebox.showinfo(APP_NAME, f"生成完成：成功 {made}，跳过 {skipped}（详见各子目录）。输出根目录：{root}")
-        self._tw_append_log(f"生成完成：成功 {made}，跳过 {skipped}，输出目录 {root}")
-        # 刷新概览
-        self.refresh_project_overview()
+        info_msg = f"生成完成：成功 {made}，跳过 {skipped}（详见各子目录）。输出根目录：{root}"
+        logs.append(f"生成完成：成功 {made}，跳过 {skipped}，输出目录 {root}")
+
+        return {
+            "logs": logs,
+            "info_msg": info_msg,
+            "warn_msg": warn_msg,
+            "preview": last_preview,
+        }
 
     def _tw_linspace(self, a: float, b: float, step: float) -> list:
         if step <= 0: return [a]
@@ -4040,26 +4231,78 @@ class VaspGUI(tk.Tk):
     # === CODEX END: generate twist/shift tasks ===
 
     # === CODEX BEGIN: collect sweep results ===
-    def _tw_collect_results(self):
+    def _tw_collect_results_btn(self):
+        project_path = self.current_project_path()
+        root = project_path / "twist_sweep"
+        self._set_busy(True, "正在汇总 sweep 结果…")
+
+        def _on_done(result: dict):
+            self._set_busy(False)
+            if not isinstance(result, dict):
+                return
+            for msg in result.get("logs", []):
+                self._tw_append_log(msg)
+            info_msg = result.get("info_msg")
+            if info_msg:
+                messagebox.showinfo(APP_NAME, info_msg)
+
+        def _on_error(exc: Exception):
+            self._set_busy(False)
+            missing_path = root / "results.csv"
+            if isinstance(exc, FileNotFoundError):
+                msg = f"未找到 {missing_path}，请先完成计算或启用演示模式。"
+                self._tw_append_log(msg)
+                messagebox.showwarning(APP_NAME, msg)
+            else:
+                self._tw_append_log(f"结果汇总失败：{exc}")
+                messagebox.showerror(APP_NAME, f"结果汇总失败：{exc}")
+
+        self._run_bg(self._tw_collect_results_core, root, True, on_done=_on_done, on_error=_on_error)
+
+    def _tw_collect_results(self, *, show_ui: bool = True, root: Path | None = None):
+        project_path = self.current_project_path()
+        root = root or (project_path / "twist_sweep")
+        try:
+            result = self._tw_collect_results_core(root, allow_demo=self.demo_mode)
+        except FileNotFoundError as exc:
+            if show_ui:
+                missing = root / "results.csv"
+                messagebox.showwarning(APP_NAME, f"未找到 {missing}，请先完成计算或启用演示模式。")
+                self._tw_append_log(str(exc))
+            raise
+        except Exception as exc:
+            if show_ui:
+                messagebox.showerror(APP_NAME, f"汇总结果失败：{exc}")
+                self._tw_append_log(f"汇总失败：{exc}")
+            raise
+        else:
+            if show_ui:
+                for msg in result.get("logs", []):
+                    self._tw_append_log(msg)
+                info_msg = result.get("info_msg")
+                if info_msg:
+                    messagebox.showinfo(APP_NAME, info_msg)
+        return result
+
+    def _tw_collect_results_core(self, root: Path, allow_demo: bool = False) -> dict:
         """遍历 twist_sweep/* 子目录，收集 gap / total energy / 备注，导出 CSV。"""
-        root = self.current_project_path() / "twist_sweep"
+        logs: list[str] = []
+        root = Path(root)
         if not root.exists():
-            if self.demo_mode:
+            if allow_demo and self.demo_mode:
                 root.mkdir(parents=True, exist_ok=True)
                 csv_path = self._tw_write_demo_results(root)
-                messagebox.showinfo(APP_NAME, f"演示模式：已生成示例 results.csv → {csv_path}")
-                self._tw_append_log("演示模式：已生成示例 twist_sweep/results.csv。")
-                return
-            messagebox.showwarning(APP_NAME, "未找到 twist_sweep 目录。")
-            self._tw_append_log("未找到 twist_sweep 目录，无法汇总结果。")
-            return
-        self._tw_append_log("开始汇总 sweep 结果…")
+                logs.append(f"演示模式：已生成示例 twist_sweep/results.csv → {csv_path}")
+                return {"logs": logs, "info_msg": f"演示模式：已生成示例 results.csv → {csv_path}", "csv_path": csv_path, "rows": []}
+            raise FileNotFoundError(f"未找到目录 {root}")
+
+        logs.append("开始汇总 sweep 结果…")
         rows = []
         for sub in sorted(root.iterdir()):
-            if not sub.is_dir(): continue
+            if not sub.is_dir():
+                continue
             theta = ux = uy = None
             try:
-                # 从目录名回读参数
                 m = re.search(r"theta_([0-9.]+)_ux_([0-9.]+)_uy_([0-9.]+)", sub.name)
                 if m:
                     theta = float(m.group(1))
@@ -4071,43 +4314,49 @@ class VaspGUI(tk.Tk):
             note = ""
             failf = sub / "FAILED.txt"
             if failf.exists():
-                note = ("FAILED: " + read_text(failf).strip().splitlines()[0][:120])
+                try:
+                    note_text = read_text(failf).strip()
+                except Exception:
+                    note_text = ""
+                if note_text:
+                    note = "FAILED: " + note_text.splitlines()[0][:120]
 
             gap_eV = None
             totalE = None
-            # 1) vasprun.xml
             vxml = sub / "vasprun.xml"
             if vxml.exists():
                 try:
                     from pymatgen.io.vasp.outputs import Vasprun
+
                     v = Vasprun(str(vxml), parse_eigen=True, parse_projected_eigen=False)
                     bg = v.get_band_structure().get_band_gap()
                     gap_eV = float(bg.get("energy")) if bg else None
-                    # 尝试总能
                     totalE = float(v.final_energy) if v.final_energy is not None else None
-                except Exception as e:
-                    if not note: note = f"vasprun parse err: {e}"
-            # 2) EIGENVAL 兜底
+                except Exception as exc:
+                    if not note:
+                        note = f"vasprun parse err: {exc}"
             if gap_eV is None:
                 gap_est, _ = self._tw_gap_from_eigenval(sub / "EIGENVAL", sub / "OUTCAR")
-                if gap_est is not None: gap_eV = gap_est
-            # 3) TOTEN 兜底
+                if gap_est is not None:
+                    gap_eV = gap_est
             if totalE is None:
                 try:
                     outcar = read_text(sub / "OUTCAR")
                     mt = re.search(r"free\s+energy\s+TOTEN\s*=\s*([-\d.Ee+]+)", outcar, flags=re.I)
-                    if mt: totalE = float(mt.group(1))
+                    if mt:
+                        totalE = float(mt.group(1))
                 except Exception:
                     pass
 
-            rows.append(dict(path=sub.name, theta=theta, ux=ux, uy=uy, gap_eV=gap_eV, totalE=totalE, note=note))
+            rows.append(
+                dict(path=sub.name, theta=theta, ux=ux, uy=uy, gap_eV=gap_eV, totalE=totalE, note=note)
+            )
 
-        # 写 CSV
         import csv
 
         csv_path = root / "results.csv"
         with csv_path.open("w", encoding="utf-8", newline="") as f:
-            writer = csv.writer(f)
+            writer = csv.writer(f, quoting=csv.QUOTE_MINIMAL)
             writer.writerow(["theta", "ux", "uy", "gap", "E", "path", "note"])
             for r in rows:
                 theta = r.get("theta")
@@ -4115,29 +4364,30 @@ class VaspGUI(tk.Tk):
                 uy = r.get("uy")
                 gap = r.get("gap_eV")
                 energy = r.get("totalE")
-                note = (r.get("note") or "").replace(",", ";").replace("\n", " ")
+                note = (r.get("note") or "").replace("\r", " ").replace("\n", " ").strip()
 
-                def _fmt_float(val):
-                    if val is None or (isinstance(val, float) and math.isnan(val)):
+                def _fmt(val: Any) -> str:
+                    if val is None:
                         return ""
                     if isinstance(val, float):
+                        if math.isnan(val):
+                            return ""
                         return f"{val:.6f}"
                     return str(val)
 
-                writer.writerow(
-                    [
-                        _fmt_float(theta),
-                        _fmt_float(ux),
-                        _fmt_float(uy),
-                        _fmt_float(gap),
-                        _fmt_float(energy),
-                        r.get("path", ""),
-                        note,
-                    ]
-                )
+                writer.writerow([
+                    _fmt(theta),
+                    _fmt(ux),
+                    _fmt(uy),
+                    _fmt(gap),
+                    _fmt(energy),
+                    r.get("path", ""),
+                    note,
+                ])
 
-        messagebox.showinfo(APP_NAME, f"已导出汇总：{csv_path}")
-        self._tw_append_log(f"结果汇总完成：共 {len(rows)} 条记录，输出 {csv_path}")
+        info_msg = f"结果汇总完成：共 {len(rows)} 条记录，输出 {csv_path}"
+        logs.append(info_msg)
+        return {"logs": logs, "info_msg": info_msg, "csv_path": csv_path, "rows": rows}
 
     def _tw_gap_from_eigenval(self, eig_path: Path, outcar_path: Path):
         """非常规兜底：从 EIGENVAL + OUTCAR(E_F) 粗略估算带隙。返回 (gap, is_direct?)；失败返回 (None,None)。"""
@@ -4552,11 +4802,13 @@ class VaspGUI(tk.Tk):
             return
         import numpy as np
 
-        rows = [
-            r
-            for r in self._tw_load_results_table()
-            if abs((r["theta"] or 0.0) - theta) < 1e-6
-        ]
+        all_rows = self._tw_load_results_table()
+        if not all_rows:
+            if not self.demo_mode:
+                missing = self.current_project_path() / "twist_sweep" / "results.csv"
+                messagebox.showwarning(APP_NAME, f"无法绘制热图：缺少 {missing}。")
+            return
+        rows = [r for r in all_rows if abs((r["theta"] or 0.0) - theta) < 1e-6]
         if not rows:
             messagebox.showwarning(APP_NAME, f"未在 results.csv 中找到 θ={theta} 的数据。")
             return
@@ -4633,6 +4885,9 @@ class VaspGUI(tk.Tk):
 
         rows = self._tw_load_results_table()
         if not rows:
+            if not self.demo_mode:
+                missing = self.current_project_path() / "twist_sweep" / "results.csv"
+                messagebox.showwarning(APP_NAME, f"无法绘制曲线：缺少 {missing}。")
             return
         by_theta: Dict[float, List[float]] = {}
         for r in rows:


### PR DESCRIPTION
## Summary
- add a distinct interlayer spacing control and place layers using absolute c-axis coordinates
- move sweep generation and result aggregation onto background threads while improving UI feedback
- harden demo/result safeguards, CSV writing, and Tk theme fallbacks for missing data

## Testing
- python -m compileall 'VASP GUI'

------
https://chatgpt.com/codex/tasks/task_e_68e11dcd660c83339bdee2c0002e7b71