### PR TITLE
Allow shear supercells and preserve bilayer thickness

### DIFF
--- a/VASP GUI
+++ b/VASP GUI
@@ -3675,7 +3675,7 @@ class VaspGUI(tk.Tk):
             pass
 
     def _tw_find_match(self, A_top_rot, A_bot, allow_strain: float, search_limit: int):
-        """返回最优匹配 dict(n1,m1,n2,m2,s,resid,area,atoms)。"""
+        """返回最优匹配 dict(S1,S2,mult_top,mult_bot,s,resid,area,atoms)。"""
         import numpy as np
 
         best: Optional[Dict[str, float]] = None
@@ -3702,13 +3702,18 @@ class VaspGUI(tk.Tk):
                 for m in matches:
                     S1 = np.array(m.get("matrix_1"), dtype=float)[:2, :2]
                     S2 = np.array(m.get("matrix_2"), dtype=float)[:2, :2]
-                    # 当前构建流程只支持对角超胞，若出现非对角项则跳过
-                    if not np.allclose(S1, np.diag(np.diag(S1))) or not np.allclose(
-                        S2, np.diag(np.diag(S2))
-                    ):
+                    if not (np.allclose(S1, np.rint(S1)) and np.allclose(S2, np.rint(S2))):
                         continue
-                    S1 = np.diag(np.diag(S1)).astype(int)
-                    S2 = np.diag(np.diag(S2)).astype(int)
+                    S1 = np.rint(S1).astype(int)
+                    S2 = np.rint(S2).astype(int)
+                    det1 = float(np.linalg.det(S1))
+                    det2 = float(np.linalg.det(S2))
+                    if np.isclose(det1, 0.0) or np.isclose(det2, 0.0):
+                        continue
+                    mult_top = int(round(abs(det1)))
+                    mult_bot = int(round(abs(det2)))
+                    if mult_top <= 0 or mult_bot <= 0:
+                        continue
                     T = A_top_rot @ S1
                     B = A_bot @ S2
                     denom = float(np.trace(T.T @ T))
@@ -3720,10 +3725,10 @@ class VaspGUI(tk.Tk):
                     )
                     area = abs(float(np.linalg.det(B)))
                     cand = dict(
-                        n1=int(S1[0, 0]),
-                        m1=int(S1[1, 1]),
-                        n2=int(S2[0, 0]),
-                        m2=int(S2[1, 1]),
+                        S1=S1,
+                        S2=S2,
+                        mult_top=mult_top,
+                        mult_bot=mult_bot,
                         s=s_star,
                         resid=resid,
                         area=area,
@@ -3740,13 +3745,15 @@ class VaspGUI(tk.Tk):
         best = None
         for n1 in range(1, search_limit + 1):
             for m1 in range(1, search_limit + 1):
-                T = A_top_rot @ np.array([[n1, 0], [0, m1]], dtype=int)
+                S1 = np.array([[n1, 0], [0, m1]], dtype=int)
+                T = A_top_rot @ S1
                 denom = float(np.trace(T.T @ T))
                 if denom <= 0:
                     continue
                 for n2 in range(1, search_limit + 1):
                     for m2 in range(1, search_limit + 1):
-                        B = A_bot @ np.array([[n2, 0], [0, m2]], dtype=int)
+                        S2 = np.array([[n2, 0], [0, m2]], dtype=int)
+                        B = A_bot @ S2
                         s_star = float(np.trace(T.T @ B) / denom)
                         if not (1.0 - allow_strain <= s_star <= 1.0 + allow_strain):
                             continue
@@ -3755,10 +3762,10 @@ class VaspGUI(tk.Tk):
                         )
                         area = abs(float(np.linalg.det(B)))
                         cand = dict(
-                            n1=n1,
-                            m1=m1,
-                            n2=n2,
-                            m2=m2,
+                            S1=S1,
+                            S2=S2,
+                            mult_top=int(n1 * m1),
+                            mult_bot=int(n2 * m2),
                             s=s_star,
                             resid=resid,
                             area=area,
@@ -3769,7 +3776,19 @@ class VaspGUI(tk.Tk):
         return best
 
     def _estimate_atoms(self, st_top, st_bot, best):
-        return len(st_top) * (best["n1"] * best["m1"]) + len(st_bot) * (best["n2"] * best["m2"])
+        import numpy as np
+
+        mult_top = best.get("mult_top")
+        mult_bot = best.get("mult_bot")
+        if mult_top is None:
+            S1 = np.array(best.get("S1", np.eye(2, dtype=int)), dtype=float)
+            mult_top = int(round(abs(np.linalg.det(S1))))
+        if mult_bot is None:
+            S2 = np.array(best.get("S2", np.eye(2, dtype=int)), dtype=float)
+            mult_bot = int(round(abs(np.linalg.det(S2))))
+        mult_top = max(1, int(mult_top))
+        mult_bot = max(1, int(mult_bot))
+        return len(st_top) * mult_top + len(st_bot) * mult_bot
 
     def _tw_build_structure(
         self,
@@ -3811,7 +3830,7 @@ class VaspGUI(tk.Tk):
         best = self._tw_find_match(A_top_rot, A_bot, allow_strain, search_limit)
 
         if best is None:
-            raise RuntimeError("在给定容许应变与搜索限内未找到可接受的对角超胞匹配。")
+            raise RuntimeError("在给定容许应变与搜索限内未找到可接受的超胞匹配。")
 
         atom_est = self._estimate_atoms(st_top, st_bot, best)
         best["atoms"] = atom_est
@@ -3822,14 +3841,20 @@ class VaspGUI(tk.Tk):
             )
 
         # 构造下层超胞
+        S2 = np.array(best.get("S2"), dtype=int)
+        if S2.shape != (2, 2):
+            raise ValueError("匹配结果缺少有效的下层超胞矩阵")
         S_bot = np.eye(3, dtype=int)
-        S_bot[0,0] = best["n2"]; S_bot[1,1] = best["m2"]
+        S_bot[:2, :2] = S2
         bot_sc = st_bot.copy()
         bot_sc.make_supercell(S_bot)
 
         # 构造上层超胞 + 旋转 + 等比例变形
+        S1 = np.array(best.get("S1"), dtype=int)
+        if S1.shape != (2, 2):
+            raise ValueError("匹配结果缺少有效的上层超胞矩阵")
         S_top = np.eye(3, dtype=int)
-        S_top[0,0] = best["n1"]; S_top[1,1] = best["m1"]
+        S_top[:2, :2] = S1
         top_sc = st_top.copy()
         top_sc.make_supercell(S_top)
 
@@ -3837,11 +3862,11 @@ class VaspGUI(tk.Tk):
         # 上层：旋转 + in-plane 等比例 s
         s = float(best["s"])
         # 取上层原笛卡尔 → 应用 Rz 与 s
-        t_cart = np.array([site.coords for site in top_sc.sites])  # (Nt,3)
+        t_cart = np.array([site.coords for site in top_sc.sites], dtype=float)  # (Nt,3)
         t_cart[:,:2] = (Rz @ t_cart[:,:2].T).T * s
 
         # 最终公共 in-plane 晶格使用 B（下层超胞矩阵 B）
-        B = A_bot @ np.array([[best["n2"],0],[0,best["m2"]]], dtype=int)
+        B = A_bot @ S2
         # 组 3×3 晶格矩阵：c 轴由层间距 + 真空决定
         interlayer = float(interlayer)
         if interlayer <= 0:
@@ -3855,22 +3880,26 @@ class VaspGUI(tk.Tk):
         def cart_to_frac(L, r):
             return np.linalg.solve(L.T, r.T).T  # (N,3)
 
-        b_cart = np.array([site.coords for site in bot_sc.sites])
+        b_cart = np.array([site.coords for site in bot_sc.sites], dtype=float)
         # 先把下层坐标重映射到以 B 为 in-plane 的晶格（原 in-plane 已经是 A_bot*n2,m2；z 保持）
         # bot_sc 现有晶格：
         # 先把它的 frac → cart（已是 cart），我们只需要映射到 L_final 的 frac：
+        # 分层放置在 z：底层位于真空中心偏下，上层位于其上 interlayer 处
+        z_bot = 0.5 * c_len - 0.5 * interlayer
+        z_top = z_bot + interlayer
+
+        # 以各层自身重心为参考保持层内厚度
+        b_center = float(np.mean(b_cart[:, 2])) if len(b_cart) else 0.0
+        t_center = float(np.mean(t_cart[:, 2])) if len(t_cart) else 0.0
+        b_cart[:, 2] = b_cart[:, 2] - b_center + z_bot
+        t_cart[:, 2] = t_cart[:, 2] - t_center + z_top
+
         b_frac_final = cart_to_frac(L_final, b_cart)
         t_frac_final = cart_to_frac(L_final, t_cart)
 
         # 施加滑移（分数坐标，沿 a1,a2）
         t_frac_final[:,0] = (t_frac_final[:,0] + ux) % 1.0
         t_frac_final[:,1] = (t_frac_final[:,1] + uy) % 1.0
-
-        # 分层放置在 z：底层位于真空中心偏下，上层位于其上 interlayer 处
-        z_bot = 0.5 * c_len - 0.5 * interlayer
-        z_top = z_bot + interlayer
-        b_frac_final[:,2] = z_bot / c_len
-        t_frac_final[:,2] = z_top / c_len
 
         # 合并为一个 Structure
         species = []
@@ -3887,20 +3916,28 @@ class VaspGUI(tk.Tk):
 
         st_final = Structure(Lattice(L_final), species, frac, site_properties=props)
 
+        mult_top = int(best.get("mult_top") or round(abs(np.linalg.det(S1))))
+        mult_bot = int(best.get("mult_bot") or round(abs(np.linalg.det(S2))))
         meta = dict(
             theta_deg=float(theta_deg),
             ux=float(ux),
             uy=float(uy),
             atoms=len(st_final),
-            n1=best["n1"],
-            m1=best["m1"],
-            n2=best["n2"],
-            m2=best["m2"],
             strain_scale=s,
             resid=best["resid"],
             vacuum=float(vacuum),
             interlayer=interlayer,
+            supercell_top=np.array(best["S1"], dtype=int).tolist(),
+            supercell_bot=np.array(best["S2"], dtype=int).tolist(),
+            mult_top=mult_top,
+            mult_bot=mult_bot,
         )
+        if np.allclose(S1, np.diag(np.diag(S1))):
+            meta["n1"] = int(S1[0, 0])
+            meta["m1"] = int(S1[1, 1])
+        if np.allclose(S2, np.diag(np.diag(S2))):
+            meta["n2"] = int(S2[0, 0])
+            meta["m2"] = int(S2[1, 1])
         return st_final, meta
     # === CODEX END: twist/shift geometry core ===
 


### PR DESCRIPTION
## Summary
- allow the twist matching routine to accept non-diagonal ZSL supercells and carry the full integer matrices through construction
- update atom counting and metadata to use general supercell determinants
- keep the intra-layer thickness when positioning the bilayers along the c axis instead of collapsing them onto single planes

## Testing
- python -m compileall 'VASP GUI'


------
https://chatgpt.com/codex/tasks/task_e_68e296b60a1883338aa90662793ba6eb